### PR TITLE
[TIMOB-23604] Android: Recompile ti.touchid module against latest SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ build
 *.zip
 .DS_Store
 .project
+android/libs
+android/build.properties
+android/dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,24 @@
 language: objective-c
+osx_image: xcode7.3
 env:
  global:
-   - "MODULE_NAME=ti.touchid" 
+   - "MODULE_NAME=ti.touchid"
+   - TRAVIS_NODE_VERSION="4"
 before_install:
     - MODULE_ROOT=$PWD
+    - brew update
+    - brew install nvm
+    - source $(brew --prefix nvm)/nvm.sh
+    - nvm install 4
+    - npm config delete prefix
+    - nvm use --delete-prefix v4.4.7 4
 install:
     - cd $MODULE_ROOT
-    - curl -o install.sh https://raw.githubusercontent.com/appcelerator-modules/ci/master/travis/install.sh
-    - source install.sh
-script: 
-    - curl -o script.sh https://raw.githubusercontent.com/appcelerator-modules/ci/master/travis/script.sh
+    - curl -o install.sh https://raw.githubusercontent.com/sgtcoolguy/ci/v8/travis/install.sh
+    - source install.sh -s "--branch master"
+script:
+    - curl -o script.sh https://raw.githubusercontent.com/sgtcoolguy/ci/v8/travis/script.sh
     - source script.sh
 after_success: # and this only on success
-  - curl -o deploy.sh https://raw.githubusercontent.com/appcelerator-modules/ci/master/travis/deploy.sh
-  - source deploy.sh
+    - curl -o deploy.sh https://raw.githubusercontent.com/appcelerator-modules/ci/master/travis/deploy.sh
+    - source deploy.sh

--- a/android/manifest
+++ b/android/manifest
@@ -2,9 +2,9 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 1.0.0
-apiversion: 2
-architectures: armeabi armeabi-v7a x86
+version: 2.0.0
+apiversion: 3
+architectures: armeabi-v7a x86
 description: Fingerprint module.
 author: Hieu Pham
 license: Apache Public License v2
@@ -16,4 +16,4 @@ name: touchid
 moduleid: ti.touchid
 guid: f0d8fd44-86d2-4730-b67d-bd454577aeee
 platform: android
-minsdk: 5.4.0
+minsdk: 6.0.0


### PR DESCRIPTION
Updates version, apiversion, minsdk (version) for Android with latest V8. Removes armeabi ABI (armeabi-v7a should be OK).

https://jira.appcelerator.org/browse/TIMOB-23604