### PR TITLE
iOS: Expose "keepAlive" flag, make "invalidate" usable from iOS < 9

### DIFF
--- a/apidoc/TouchId.yml
+++ b/apidoc/TouchId.yml
@@ -420,6 +420,8 @@ properties:
     
   - name: fallbackTitle
     summary: |
+        Note: This property is iOS only!
+
         Allows fallback button title customization. A default localized title 
         "Enter Password" is used when this property is left nil. If set to empty 
         string, the button will be hidden.
@@ -429,6 +431,8 @@ properties:
     
   - name: cancelTitle
     summary: |
+         Note: This property is iOS only!
+
         Allows cancel button title customization. A default localized title "Cancel" 
         is used when this property is not defined or is set to empty string.
     type: String
@@ -437,6 +441,8 @@ properties:
      
   - name: keepAlive
     summary: |
+        Note: This property is iOS only!
+
         Determines whether the auth-context should be kept alive after authorizing
         with the TouchID-API and can be used to automatically terminate an auth-context
         after authorizing. 

--- a/apidoc/TouchId.yml
+++ b/apidoc/TouchId.yml
@@ -35,12 +35,12 @@ description: |
 
     Use `require()` to access the module from JavaScript:
 
-        var TouchId = require("ti.touchid");
+        var TouchID = require('ti.touchid');
 
     The `TouchId` variable is a reference to the module. Make API calls using this reference:
 
-        TouchId.authenticate({
-            reason: "Need to modify personal settings.",
+        TouchID.authenticate({
+            reason: 'Verify to modify personal settings',
             callback: function(e) {
                 Ti.API.info(e);
             }
@@ -48,10 +48,10 @@ description: |
         
     ### Lifetime Notes (iOS-only)
     
-    The current context will, once evaluated, been used until it's instance gets released or invalidated.
-    You can you use the <Modules.TouchId.invalidate> method to force the user to be prompted everytime a
-    new 
-    tion is triggered.
+    The current context will, once evaluated, be used until it's instance gets released or invalidated.
+    You can you use the <Modules.TouchId.invalidate> method to force the user to be prompted every time a
+    new authentication is triggered. On iOS 9 and later, this can also be called to cancel a current 
+    evaluation of an auth-context, e.g. to hide the auth-dialoag.
         
     ### Native Keychain Integration (iOS-only)
     
@@ -63,7 +63,7 @@ description: |
     The module contains a sample application in the
     `<TITANIUM_SDK_HOME>/modules/iphone/ti.touchid/<VERSION>/example/` folder.
 
-methods:    
+methods:
   - name: authenticate
     summary: Initiates the Touch ID authentication process.
     description: |
@@ -87,6 +87,8 @@ methods:
         Invalidation terminates any existing policy evaluation and the respective call will
         fail with <Modules.TouchId.ERROR_APP_CANCELLED>. After the context has been invalidated, it can not be
         used for policy evaluation and an attempt to do so will fail with <Modules.TouchId.ERROR_INVALID_CONTEXT>.
+        
+        See the "Lifetime Notes (iOS-only)" paragraph in the module paragraph for more infos.
     
     platforms: [iphone, ipad, android]
     since: "6.1.0"
@@ -100,7 +102,7 @@ methods:
             if (!result.canAuthenticate) {
                 alert('Message: ' + result.error + '\nCode: ' + result.code);  
             } else {
-                alert('device can authenticate');
+                alert('Device can authenticate');
             }
     returns:
         type: DeviceCanAuthenticateResult
@@ -123,7 +125,7 @@ properties:
     type: Number
     constants: [Modules.TouchId.AUTHENTICATION_POLICY_*]
     default: Modules.TouchId.AUTHENTICATION_POLICY_BIOMETRICS
-    
+
   - name: AUTHENTICATION_POLICY_PASSCODE
     summary: Device owner was authenticated by Touch ID or device passcode.
     description: |
@@ -432,6 +434,22 @@ properties:
     type: String
     since: "6.1.0"
     osver: {ios: {min: "10.0"}}
+     
+  - name: keepAlive
+    summary: |
+        Determines whether the auth-context should be kept alive after authorizing
+        with the TouchID-API and can be used to automatically terminate an auth-context
+        after authorizing. 
+        
+        Please note that calling `invalidate` will not be possible unless you 
+        have a valid auth-context, so you would decide whether to use `invalidate` 
+        to invalidate the context and release the auth-instance or use the `keepAlive` 
+        property inside `authenticate` to only terminate the context.
+        
+        Terminated contexts cannot be recovered and will be recreated with a new auth-context
+        once `authenticate` is called again.
+    type: Boolean
+    since: "7.0.0"
   
   - name: callback
     optional: false

--- a/ios/Classes/TiTouchidModule.h
+++ b/ios/Classes/TiTouchidModule.h
@@ -9,8 +9,8 @@
 #import "TiModule.h"
 
 @interface TiTouchidModule : TiModule {
-    LAContext *authContext;
-    LAPolicy authPolicy;
+    LAContext *_authContext;
+    LAPolicy _authPolicy;
 }
 
 /**

--- a/ios/TouchID.xcodeproj/project.pbxproj
+++ b/ios/TouchID.xcodeproj/project.pbxproj
@@ -247,6 +247,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DSTROOT = /tmp/TiTouchid.dst;
+				ENABLE_BITCODE = NO;
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -284,6 +285,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				DSTROOT = /tmp/TiTouchid.dst;
+				ENABLE_BITCODE = NO;
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_MODEL_TUNING = G5;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;

--- a/ios/manifest
+++ b/ios/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.1.3
+version: 2.1.4
 apiversion: 2
 architectures: armv7 arm64 i386 x86_64
 description: TouchId Module


### PR DESCRIPTION
**JIRA**: https://jira.appcelerator.org/browse/MOD-2356

**Prerelease**: [ti.touchid-iphone-2.1.4.zip](https://github.com/appcelerator-modules/ti.touchid/files/1267435/ti.touchid-iphone-2.1.4.zip)
