### PR TITLE
[TIMOB-25225] Android: Fix resume state and exception feedback

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.2.1
+version: 2.2.2
 apiversion: 3
 architectures: armeabi-v7a x86
 description: Fingerprint module.

--- a/android/src/ti/touchid/KeychainItemProxy.java
+++ b/android/src/ti/touchid/KeychainItemProxy.java
@@ -351,12 +351,19 @@ public class KeychainItemProxy extends KrollProxy {
 			int length = 0;
 			int total = 0;
 			String decrypted = "";
+
+			// since we only encrypt strings, this is acceptable
 			while ((length = cis.read(buffer)) != -1) {
-				// since we only encrypt strings, this is acceptable
-				decrypted += new String(buffer, StandardCharsets.UTF_8);
+				// obtain decrypted string from buffer
+				String part = new String(buffer, StandardCharsets.UTF_8);
+
+				// remove trailing terminators
+				part = part.substring(0, length).replaceFirst("\u0000+$", "");
+
+				// append to decrypted string
+				decrypted += part;
 				total += length;
 			}
-			decrypted = decrypted.substring(0, total).replaceFirst("\u0000+$", "");
 
 			result.put("success", true);
 			result.put("code", 0);


### PR DESCRIPTION
- Return exception messages through `deviceCanAuthenticate()` result
- Initialize `fingerprintHelper` when calling `authenticate()` `deviceCanAuthenticate()` and `isSupported()`
- Fix decoding of decrypted data

###### TEST CASE
```JS
var win = Ti.UI.createWindow({title: 'TIMOB-', backgroundColor: 'gray'}),
    lbl = Ti.UI.createLabel({text: 'UNAUTHORIZED'}),
    touchID = require('ti.touchid'),
    result = touchID.deviceCanAuthenticate(),
    authorized = false;

if (result.error && result.error.includes('least one fingerprint')) {
    alert('Please setup a fingerprint on device for authentication.');
}

win.addEventListener('focus', function(e) {
    if (!authorized) {
        touchID.authenticate({
            callback : function(e) {
                authorized = true;
                lbl.text = 'AUTHORIZED';
                alert('e :' + JSON.stringify(e));
            }
        });
    }
});

win.add(lbl);
win.open();
```

[TIMOB-25225](https://jira.appcelerator.org/browse/TIMOB-25225)
[MOD-2363](https://jira.appcelerator.org/browse/MOD-2363)